### PR TITLE
feat: Run database migrations on backend startup in Docker

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -8,8 +8,8 @@
       "name": "backend",
       "version": "1.0.0",
       "dependencies": {
+        "@prisma/client": "^6.9.0",
         "express": "^4.17.1",
-        "prisma": "^6.9.0",
         "swagger-jsdoc": "^6.2.8",
         "swagger-ui-express": "^5.0.1"
       },
@@ -19,6 +19,7 @@
         "@types/swagger-jsdoc": "^6.0.4",
         "@types/swagger-ui-express": "^4.1.8",
         "nodemon": "^2.0.22",
+        "prisma": "^6.9.0",
         "ts-node": "^10.9.2",
         "typescript": "^5.8.3"
       }
@@ -105,10 +106,32 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
+    "node_modules/@prisma/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-Gg7j1hwy3SgF1KHrh0PZsYvAaykeR0PaxusnLXydehS96voYCGt1U5zVR31NIouYc63hWzidcrir1a7AIyCsNQ==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=18.18"
+      },
+      "peerDependencies": {
+        "prisma": "*",
+        "typescript": ">=5.1.0"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@prisma/config": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/config/-/config-6.9.0.tgz",
       "integrity": "sha512-Wcfk8/lN3WRJd5w4jmNQkUwhUw0eksaU/+BlAJwPQKW10k0h0LC9PD/6TQFmqKVbHQL0vG2z266r0S1MPzzhbA==",
+      "devOptional": true,
       "dependencies": {
         "jiti": "2.4.2"
       }
@@ -116,12 +139,14 @@
     "node_modules/@prisma/debug": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-6.9.0.tgz",
-      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg=="
+      "integrity": "sha512-bFeur/qi/Q+Mqk4JdQ3R38upSYPebv5aOyD1RKywVD+rAMLtRkmTFn28ZuTtVOnZHEdtxnNOCH+bPIeSGz1+Fg==",
+      "devOptional": true
     },
     "node_modules/@prisma/engines": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-6.9.0.tgz",
       "integrity": "sha512-im0X0bwDLA0244CDf8fuvnLuCQcBBdAGgr+ByvGfQY9wWl6EA+kRGwVk8ZIpG65rnlOwtaWIr/ZcEU5pNVvq9g==",
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/debug": "6.9.0",
@@ -133,12 +158,14 @@
     "node_modules/@prisma/engines-version": {
       "version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e.tgz",
-      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q=="
+      "integrity": "sha512-Qp9gMoBHgqhKlrvumZWujmuD7q4DV/gooEyPCLtbkc13EZdSz2RsGUJ5mHb3RJgAbk+dm6XenqG7obJEhXcJ6Q==",
+      "devOptional": true
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-6.9.0.tgz",
       "integrity": "sha512-PMKhJdl4fOdeE3J3NkcWZ+tf3W6rx3ht/rLU8w4SXFRcLhd5+3VcqY4Kslpdm8osca4ej3gTfB3+cSk5pGxgFg==",
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "6.9.0",
         "@prisma/engines-version": "6.9.0-10.81e4af48011447c3cc503a190e86995b66d2a28e",
@@ -149,6 +176,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-6.9.0.tgz",
       "integrity": "sha512-/B4n+5V1LI/1JQcHp+sUpyRT1bBgZVPHbsC4lt4/19Xp4jvNIVcq5KYNtQDk5e/ukTSjo9PZVAxxy9ieFtlpTQ==",
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "6.9.0"
       }
@@ -987,6 +1015,7 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
       "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
+      "devOptional": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
@@ -1236,6 +1265,7 @@
       "version": "6.9.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-6.9.0.tgz",
       "integrity": "sha512-resJAwMyZREC/I40LF6FZ6rZTnlrlrYrb63oW37Gq+U+9xHwbyMSPJjKtM7VZf3gTO86t/Oyz+YeSXr3CmAY1Q==",
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/config": "6.9.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "start": "node dist/server.js",
     "dev": "nodemon src/server.ts",
-    "build": "tsc"
+    "build": "tsc",
+    "migrate:dev": "prisma migrate dev",
+    "migrate:deploy": "prisma migrate deploy"
   },
   "dependencies": {
+    "@prisma/client": "^6.9.0",
     "express": "^4.17.1",
-    "prisma": "^6.9.0",
     "swagger-jsdoc": "^6.2.8",
     "swagger-ui-express": "^5.0.1"
   },
@@ -20,6 +22,7 @@
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^2.0.22",
+    "prisma": "^6.9.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
   }

--- a/backend/prisma/migrations/0_init/migration.sql
+++ b/backend/prisma/migrations/0_init/migration.sql
@@ -1,0 +1,90 @@
+-- CreateTable
+CREATE TABLE "User" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "User_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ApiSpecification" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "content" JSONB NOT NULL,
+    "userId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ApiSpecification_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "PostmanCollection" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "apiSpecificationId" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PostmanCollection_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TestCase" (
+    "id" TEXT NOT NULL,
+    "itemJson" JSONB NOT NULL,
+    "collectionId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "TestCase_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TestRun" (
+    "id" TEXT NOT NULL,
+    "runAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "status" TEXT NOT NULL,
+    "postmanCollectionId" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "summary" JSONB,
+
+    CONSTRAINT "TestRun_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "TestRunExecution" (
+    "id" TEXT NOT NULL,
+    "testRunId" TEXT NOT NULL,
+    "requestName" TEXT NOT NULL,
+    "requestDetails" JSONB NOT NULL,
+    "responseDetails" JSONB,
+    "assertions" JSONB,
+    "status" TEXT NOT NULL,
+
+    CONSTRAINT "TestRunExecution_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- AddForeignKey
+ALTER TABLE "ApiSpecification" ADD CONSTRAINT "ApiSpecification_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostmanCollection" ADD CONSTRAINT "PostmanCollection_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "PostmanCollection" ADD CONSTRAINT "PostmanCollection_apiSpecificationId_fkey" FOREIGN KEY ("apiSpecificationId") REFERENCES "ApiSpecification"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestCase" ADD CONSTRAINT "TestCase_collectionId_fkey" FOREIGN KEY ("collectionId") REFERENCES "PostmanCollection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestRun" ADD CONSTRAINT "TestRun_postmanCollectionId_fkey" FOREIGN KEY ("postmanCollectionId") REFERENCES "PostmanCollection"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestRun" ADD CONSTRAINT "TestRun_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "TestRunExecution" ADD CONSTRAINT "TestRunExecution_testRunId_fkey" FOREIGN KEY ("testRunId") REFERENCES "TestRun"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -1,0 +1,77 @@
+// schema.prisma
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}
+
+model User {
+  id                 String              @id @default(cuid())
+  email              String              @unique
+  password           String
+  createdAt          DateTime            @default(now())
+  apiSpecifications  ApiSpecification[]
+  postmanCollections PostmanCollection[]
+  testRuns           TestRun[]
+}
+
+model ApiSpecification {
+  id                   String              @id @default(cuid())
+  name                 String
+  content              Json
+  user                 User                @relation(fields: [userId], references: [id])
+  userId               String
+  createdAt            DateTime            @default(now())
+  generatedCollections PostmanCollection[]
+}
+
+model PostmanCollection {
+  id                 String           @id @default(cuid())
+  name               String
+  user               User             @relation(fields: [userId], references: [id])
+  userId             String
+  apiSpecification   ApiSpecification? @relation(fields: [apiSpecificationId], references: [id])
+  apiSpecificationId String?
+  createdAt          DateTime         @default(now())
+  testCases          TestCase[]
+  testRuns           TestRun[]
+}
+
+// Unified model for all test cases, storing the complete Postman Item object.
+model TestCase {
+  id           String            @id @default(cuid())
+  // The full Postman Item JSON object, including name, request, and the event array with test scripts.
+  itemJson     Json
+  collection   PostmanCollection @relation(fields: [collectionId], references: [id])
+  collectionId String
+  createdAt    DateTime          @default(now())
+}
+
+// Stores a summary of a single collection run
+model TestRun {
+  id                  String             @id @default(cuid())
+  runAt               DateTime           @default(now())
+  status              String             // "PENDING", "COMPLETED", "FAILED"
+  postmanCollection   PostmanCollection  @relation(fields: [postmanCollectionId], references: [id])
+  postmanCollectionId String
+  user                User               @relation(fields: [userId], references: [id])
+  userId              String
+  summary             Json?              // Store Newman's run.stats and run.timings
+  executions          TestRunExecution[]
+}
+
+// Stores the detailed result of a single request within a TestRun
+model TestRunExecution {
+  id              String   @id @default(cuid())
+  testRun         TestRun  @relation(fields: [testRunId], references: [id])
+  testRunId       String
+  requestName     String
+  requestDetails  Json
+  responseDetails Json?
+  assertions      Json?    // Store Newman's execution.assertions array
+  status          String   // "passed" or "failed"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     build: ./backend
     ports:
       - "8000:8000"
+    command: sh -c "npm run migrate:deploy && npm start"
     volumes:
       - ./backend:/app/backend
       # Mount the backend directory to /app/backend for development


### PR DESCRIPTION
This commit updates the `docker-compose.yml` file to ensure that database migrations are applied automatically when the `backend` service starts.

The `backend` service command is modified to:
`sh -c "npm run migrate:deploy && npm start"`

This uses the `migrate:deploy` npm script (which executes `prisma migrate deploy`) to apply any pending migrations before starting the Node.js application.