### PR TITLE
feat: Use environment variable for JWT secret

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,7 @@
+# Prisma
+DATABASE_URL="postgresql://user:password@localhost:5432/mydb?schema=public"
+
+# JWT Authentication
+# IMPORTANT: Replace the placeholder below with the actual strong secret you generated.
+# Keep your actual .env file (with the real secret) out of version control.
+JWT_SECRET="YOUR_GENERATED_STRONG_SECRET_HERE"

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env.development.local
 .env.test.local
 .env.production.local
+.env

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -4,7 +4,13 @@ import jwt from 'jsonwebtoken';
 
 const prisma = new PrismaClient();
 
-const JWT_SECRET = 'YOUR_SECRET_KEY'; // Placeholder for JWT secret
+// Check for JWT_SECRET in environment variables
+if (!process.env.JWT_SECRET) {
+  console.error("FATAL ERROR: JWT_SECRET is not defined in environment variables.");
+  // In a real app, you might want to exit the process or prevent server start more gracefully
+  throw new Error("FATAL ERROR: JWT_SECRET is not defined. Server cannot start without it.");
+}
+const JWT_SECRET = process.env.JWT_SECRET;
 
 /**
  * Registers a new user.


### PR DESCRIPTION
This commit updates the application to use an environment variable for the JWT secret, enhancing security and configurability.

Changes include:
- Modified `auth.service.ts` to retrieve the JWT_SECRET from `process.env.JWT_SECRET`.
- Added a startup check in `auth.service.ts` to ensure JWT_SECRET is defined, throwing an error if it's missing.
- Created `backend/.env.example` to provide a template for required environment variables, including `DATABASE_URL` and `JWT_SECRET`, with instructions for setting the actual secret.
- Updated `backend/.gitignore` to ensure `.env` files are not committed to the repository.

A strong JWT secret was generated and provided to you to be manually added to your local `.env` file.